### PR TITLE
fix: only sleep when the time to sleep is non-negative

### DIFF
--- a/src/monitor/mod.rs
+++ b/src/monitor/mod.rs
@@ -206,12 +206,13 @@ impl Monitor {
                 }
             };
 
+            let sleep_time = tokio::time::Duration::from_secs(30 * 60 / list_len as u64);
+
             /* Space updating characters evenly over a 30 minute period. */
             let elapsed = now.elapsed();
-            tokio::time::sleep(
-                tokio::time::Duration::from_secs(30 * 60 / list_len as u64) - elapsed,
-            )
-            .await;
+            if elapsed < sleep_time {
+                tokio::time::sleep(sleep_time - elapsed).await;
+            }
         }
     }
 


### PR DESCRIPTION
If the updating of the character took longer than the time between updates, it would attempt to sleep for negative amounts.

Fixes #9.